### PR TITLE
feat: add subpackage routes to the tailwind config

### DIFF
--- a/packages/ui/tailwind.config.ts
+++ b/packages/ui/tailwind.config.ts
@@ -9,6 +9,8 @@ const config = {
     "./app/**/*.{ts,tsx}",
     "./src/**/*.{ts,tsx}",
     "../../packages/ui/src/**/*.{ts,tsx}",
+    "../../packages/code-generator/src/**/*.{ts,tsx}",
+    "../../packages/parser/src/**/*.{ts,tsx}",
   ],
   prefix: "",
   theme: {


### PR DESCRIPTION
Moving the components from `/next` app to the subpackages `parser` and `code-generator` had a side-effect where used tailwind classes did not bring any styling. 

To solve this, I've introduced these packages route to the tailwind config in our `ui` package; which seems to be working now.

I see `../../packages/` being repeated in other places as well; so maybe it could be a good idea to have all of these in one place, idk 🤔 