### PR TITLE
Grab variables for params

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,9 @@
   "workspaces": [
     "apps/*",
     "packages/*"
-  ]
+  ],
+  "dependencies": {
+    "@ts-morph/bootstrap": "^0.23.0",
+    "ts-morph": "^22.0.0"
+  }
 }

--- a/packages/code-generator/src/CodeGenerator/context.tsx
+++ b/packages/code-generator/src/CodeGenerator/context.tsx
@@ -57,7 +57,7 @@ export const CodeGeneratorProvider: React.FC<PropsWithChildren> = ({
   }, []);
 
   useEffect(() => {
-    setCode(generateCode(functions));
+    setCode(generateCode(functions, variables));
     setVariables(extractVariables(functions));
   }, [functions, setFunctions]);
 

--- a/packages/code-generator/src/CodeGenerator/context.tsx
+++ b/packages/code-generator/src/CodeGenerator/context.tsx
@@ -1,26 +1,41 @@
-import { PropsWithChildren, createContext, useContext, useState } from "react";
-import { FunctionInfo } from "@repo/parser";
+import { FunctionInfo, VariableInfo } from "@repo/parser";
+import {
+  PropsWithChildren,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import { generateCode } from "./functions";
 
 interface Context {
   functions: FunctionInfo[];
   setFunctions: (functions: FunctionInfo[]) => void;
+  code: string;
 }
 
 const CodeGeneratorContext = createContext<Context>({
   functions: [],
   setFunctions: () => {},
+  code: "",
 });
 
 export const CodeGeneratorProvider: React.FC<PropsWithChildren> = ({
   children,
 }) => {
   const [functions, setFunctions] = useState<FunctionInfo[]>([]);
+  const [code, setCode] = useState<string>("");
+
+  useEffect(() => {
+    setCode(generateCode(functions));
+  }, [functions, setFunctions]);
 
   return (
     <CodeGeneratorContext.Provider
       value={{
         functions,
         setFunctions,
+        code,
       }}
     >
       {children}

--- a/packages/code-generator/src/CodeGenerator/context.tsx
+++ b/packages/code-generator/src/CodeGenerator/context.tsx
@@ -1,4 +1,4 @@
-import { FunctionInfo, VariableInfo } from "@repo/parser";
+import { FunctionInfo } from "@repo/parser";
 import {
   PropsWithChildren,
   createContext,
@@ -6,36 +6,71 @@ import {
   useEffect,
   useState,
 } from "react";
-import { generateCode } from "./functions";
+import {
+  VariableInfoWithIndex,
+  extractVariables,
+  generateCode,
+} from "./functions";
+import { createProject, ts, Project } from "@ts-morph/bootstrap";
 
 interface Context {
   functions: FunctionInfo[];
+  variables: VariableInfoWithIndex[];
   setFunctions: (functions: FunctionInfo[]) => void;
   code: string;
+  project: Project | null;
+  program: ts.Program | null;
+  sourceFile: ts.SourceFile | null;
 }
 
 const CodeGeneratorContext = createContext<Context>({
   functions: [],
+  variables: [],
   setFunctions: () => {},
   code: "",
+  project: null,
+  program: null,
+  sourceFile: null,
 });
 
 export const CodeGeneratorProvider: React.FC<PropsWithChildren> = ({
   children,
 }) => {
   const [functions, setFunctions] = useState<FunctionInfo[]>([]);
+  const [variables, setVariables] = useState<VariableInfoWithIndex[]>([]);
   const [code, setCode] = useState<string>("");
+  const [project, setProject] = useState<Project | null>(null);
+  const [program, setProgram] = useState<ts.Program | null>(null);
+  const [sourceFile, setSourceFile] = useState<ts.SourceFile | null>(null);
+
+  useEffect(() => {
+    const initializeTsMorph = async () => {
+      const project = await createProject({ useInMemoryFileSystem: true });
+      const sourceFile = project.createSourceFile("index.ts", "");
+      const program = project.createProgram();
+      setProject(project);
+      setSourceFile(sourceFile);
+      setProgram(program);
+    };
+
+    initializeTsMorph();
+  }, []);
 
   useEffect(() => {
     setCode(generateCode(functions));
+    setVariables(extractVariables(functions));
   }, [functions, setFunctions]);
 
   return (
     <CodeGeneratorContext.Provider
       value={{
         functions,
+        variables,
         setFunctions,
         code,
+        project,
+        program,
+        sourceFile,
       }}
     >
       {children}

--- a/packages/code-generator/src/CodeGenerator/context.tsx
+++ b/packages/code-generator/src/CodeGenerator/context.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren, createContext, useContext, useState } from "react";
 import { FunctionInfo } from "@repo/parser";
 
 interface Context {
-  functions: any[];
+  functions: FunctionInfo[];
   setFunctions: (functions: FunctionInfo[]) => void;
 }
 

--- a/packages/code-generator/src/CodeGenerator/functions.test.ts
+++ b/packages/code-generator/src/CodeGenerator/functions.test.ts
@@ -25,7 +25,7 @@ describe("createFunctionCall", () => {
       variables: [],
     };
 
-    const result = createFunctionCall(functionInfo);
+    const result = createFunctionCall(functionInfo, [], 0);
     const codeString = ts
       .createPrinter()
       .printNode(
@@ -56,7 +56,7 @@ describe("createFunctionCall", () => {
       variables: [],
     };
 
-    const result = createFunctionCall(functionInfo);
+    const result = createFunctionCall(functionInfo, [], 0);
     const codeString = ts
       .createPrinter()
       .printNode(
@@ -78,7 +78,7 @@ describe("createFunctionCall", () => {
       variables: [],
     };
 
-    const result = createFunctionCall(functionInfo);
+    const result = createFunctionCall(functionInfo, [], 0);
     const codeString = ts
       .createPrinter()
       .printNode(
@@ -109,7 +109,7 @@ describe("createFunctionCall", () => {
       variables: [],
     };
 
-    const result = createFunctionCall(functionInfo);
+    const result = createFunctionCall(functionInfo, [], 0);
     const codeString = ts
       .createPrinter()
       .printNode(
@@ -133,7 +133,7 @@ describe("createVariableWithFunctionCall", () => {
       variables: [],
     };
 
-    const result = createVariableWithFunctionCall(functionInfo, 0);
+    const result = createVariableWithFunctionCall(functionInfo, [], 0);
     const codeString = ts
       .createPrinter()
       .printNode(
@@ -164,7 +164,7 @@ describe("createVariableWithFunctionCall", () => {
       variables: [],
     };
 
-    const result = createVariableWithFunctionCall(functionInfo, 0);
+    const result = createVariableWithFunctionCall(functionInfo, [], 0);
     const codeString = ts
       .createPrinter()
       .printNode(

--- a/packages/code-generator/src/CodeGenerator/functions.test.ts
+++ b/packages/code-generator/src/CodeGenerator/functions.test.ts
@@ -1,9 +1,12 @@
 import ts from "typescript";
 import {
+  VariableInfoWithIndex,
   createFunctionCall,
   createVariableWithFunctionCall,
+  extractVariables,
   generateCode,
 } from "./functions";
+import { FunctionInfo } from "@parser/module-parser/types";
 
 describe("dummy test for 'packages/code-generator'", () => {
   it("should pass", () => {
@@ -130,7 +133,7 @@ describe("createVariableWithFunctionCall", () => {
       variables: [],
     };
 
-    const result = createVariableWithFunctionCall(functionInfo);
+    const result = createVariableWithFunctionCall(functionInfo, 0);
     const codeString = ts
       .createPrinter()
       .printNode(
@@ -161,7 +164,7 @@ describe("createVariableWithFunctionCall", () => {
       variables: [],
     };
 
-    const result = createVariableWithFunctionCall(functionInfo);
+    const result = createVariableWithFunctionCall(functionInfo, 0);
     const codeString = ts
       .createPrinter()
       .printNode(
@@ -171,5 +174,71 @@ describe("createVariableWithFunctionCall", () => {
       );
 
     expect(codeString).toBe("const myfunction = myFunction(name, age);");
+  });
+});
+
+describe("extractVariables", () => {
+  it("should extract variables with their types and indices", () => {
+    const functionInfos: FunctionInfo[] = [
+      {
+        name: "myFunction",
+        returnType: "void",
+        parameters: [],
+        jsDocComment: "This is a test function.",
+        code: "function myFunction() {\n  console.log('Hello, world!');\n}",
+        variables: [],
+      },
+      {
+        name: "greetUser",
+        returnType: "Promise<string>",
+        parameters: [
+          {
+            name: "name",
+            type: "string",
+          },
+        ],
+        jsDocComment: "This function greets a user.",
+        code: "async function greetUser(name: string) {\n  return `Hello, ${name}!`;\n}",
+        variables: [],
+      },
+      {
+        name: "calculateSum",
+        returnType: "number",
+        parameters: [
+          {
+            name: "a",
+            type: "number",
+          },
+          {
+            name: "b",
+            type: "number",
+          },
+        ],
+        jsDocComment: "This function calculates the sum of two numbers.",
+        code: "function calculateSum(a: number, b: number) {\n  return a + b;\n}",
+        variables: [],
+      },
+    ];
+
+    const expectedVariables: VariableInfoWithIndex[] = [
+      {
+        name: "myfunction",
+        type: "void",
+        index: 0,
+      },
+      {
+        name: "greetuser",
+        type: "string",
+        index: 1,
+      },
+      {
+        name: "calculatesum",
+        type: "number",
+        index: 2,
+      },
+    ];
+
+    const result = extractVariables(functionInfos);
+    expect(result).toEqual(expectedVariables);
   });
 });

--- a/packages/code-generator/src/CodeGenerator/functions.test.ts
+++ b/packages/code-generator/src/CodeGenerator/functions.test.ts
@@ -8,6 +8,129 @@ import {
 } from "./functions";
 import { FunctionInfo } from "@parser/module-parser/types";
 
+const fetchDataFunctionInfo: FunctionInfo = {
+  name: "fetchData",
+  returnType: "Promise<User[]>",
+  parameters: [],
+  jsDocComment: "Fetches user data from an API.",
+  code: 'export async function fetchData(): Promise<User[]> {\n  const response = await fetch("https://jsonplaceholder.typicode.com/posts");\n  const data: User[] = await response.json();\n  return data;\n}',
+  variables: [
+    {
+      name: "response",
+      type: "any",
+    },
+    {
+      name: "data",
+      type: "User[]",
+    },
+  ],
+};
+
+const fetchExtraDataFunctionInfo: FunctionInfo = {
+  name: "fetchExtraData",
+  returnType: "Promise<Todo[]>",
+  parameters: [],
+  jsDocComment: "Fetches extra data from an API.",
+  code: 'export async function fetchExtraData(): Promise<Todo[]> {\n  const response = await fetch("https://jsonplaceholder.typicode.com/todos");\n  const data: Todo[] = await response.json();\n  return data;\n}',
+  variables: [
+    {
+      name: "response",
+      type: "any",
+    },
+    {
+      name: "data",
+      type: "Todo[]",
+    },
+  ],
+};
+
+const parseDataFunctionInfo: FunctionInfo = {
+  name: "parseData",
+  returnType: "User[]",
+  parameters: [
+    {
+      name: "data",
+      type: "User[]",
+    },
+  ],
+  jsDocComment:
+    "Parses user data and modifies the title property to be in uppercase.",
+  code: "export function parseData(data: User[]): User[] {\n  return data.map((user) => {\n    return {\n      ...user,\n      title: user.title.toUpperCase(),\n    };\n  });\n}",
+  variables: [],
+};
+
+const XFunctionInfo: FunctionInfo = {
+  name: "X",
+  returnType: "string",
+  parameters: [],
+  jsDocComment: "Dummy function that returns a string",
+  code: 'export function X(): string {\n  return "X";\n}',
+  variables: [],
+};
+
+const YFunctionInfo: FunctionInfo = {
+  name: "Y",
+  returnType: "Promise<string>",
+  parameters: [],
+  jsDocComment: "Dummy async function that returns a string after 1 second.",
+  code: 'export async function Y(): Promise<string> {\n  await new Promise((resolve) => setTimeout(resolve, 1000));\n  return "Y";\n}',
+  variables: [],
+};
+
+const ZFunctionInfo: FunctionInfo = {
+  name: "Z",
+  returnType: "void",
+  parameters: [],
+  jsDocComment: "Dummy function that returns nothing",
+  code: "export function Z(): void {\n  return;\n}",
+  variables: [],
+};
+
+const functionInfos: FunctionInfo[] = [
+  fetchDataFunctionInfo,
+  fetchExtraDataFunctionInfo,
+  parseDataFunctionInfo,
+  XFunctionInfo,
+  YFunctionInfo,
+  ZFunctionInfo,
+];
+
+// Variable Infos
+const variableInfos: VariableInfoWithIndex[] = [
+  {
+    name: "fetchdata",
+    type: "User[]",
+    index: 0,
+  },
+  {
+    name: "fetchextradata",
+    type: "Todo[]",
+    index: 1,
+  },
+  {
+    name: "parsedata",
+    type: "User[]",
+    index: 2,
+  },
+  {
+    name: "x",
+    type: "string",
+    index: 3,
+  },
+  {
+    name: "y",
+    type: "string",
+    index: 4,
+  },
+  {
+    name: "z",
+    type: "void",
+    index: 5,
+  },
+];
+
+export { functionInfos, variableInfos };
+
 describe("dummy test for 'packages/code-generator'", () => {
   it("should pass", () => {
     expect(true).toBe(true);
@@ -174,6 +297,27 @@ describe("createVariableWithFunctionCall", () => {
       );
 
     expect(codeString).toBe("const myfunction = myFunction(name, age);");
+  });
+
+  it("should create a variable declaration with a unique name if the variable name is already used", () => {
+    const functionInfo = functionInfos[0]; // fetchDataFunctionInfo
+    const variables = variableInfos;
+    const index = functionInfos.length;
+
+    const result = createVariableWithFunctionCall(
+      functionInfo,
+      variables,
+      index
+    );
+    const codeString = ts
+      .createPrinter()
+      .printNode(
+        ts.EmitHint.Unspecified,
+        result,
+        ts.createSourceFile("", "", ts.ScriptTarget.Latest)
+      );
+
+    expect(codeString).toBe("const fetchdata2 = await fetchData();");
   });
 });
 

--- a/packages/code-generator/src/CodeGenerator/functions.ts
+++ b/packages/code-generator/src/CodeGenerator/functions.ts
@@ -42,8 +42,15 @@ export function createVariableWithFunctionCall(
   variables: VariableInfoWithIndex[],
   index: number
 ): ts.VariableStatement {
+  const variableName = functionInfo.name.toLowerCase();
+  const existingVariables = variables.filter(
+    (v) => v.name.startsWith(variableName) && v.index < index
+  );
+  const variableCount = existingVariables.length;
+
   const variableInfo: VariableInfoWithIndex = {
-    name: functionInfo.name.toLowerCase(),
+    name:
+      variableCount > 0 ? `${variableName}${variableCount + 1}` : variableName,
     type: functionInfo.returnType || "any",
     index,
   };

--- a/packages/code-generator/src/CodeGenerator/index.tsx
+++ b/packages/code-generator/src/CodeGenerator/index.tsx
@@ -54,8 +54,10 @@ const FunctionDropZone: React.FC = () => {
 };
 
 export const CodeGenerator: React.FC = () => {
-  const { functions, setFunctions, code } = useCodeGenerator();
+  const { functions, setFunctions, code, variables } = useCodeGenerator();
   const isEmpty = functions.length === 0;
+
+  console.log(variables);
 
   const outputWithBreakLine = code.replace(/;/g, ";\n").replace(/{/g, "{\n");
 

--- a/packages/code-generator/src/CodeGenerator/index.tsx
+++ b/packages/code-generator/src/CodeGenerator/index.tsx
@@ -57,8 +57,6 @@ export const CodeGenerator: React.FC = () => {
   const { functions, setFunctions, code, variables } = useCodeGenerator();
   const isEmpty = functions.length === 0;
 
-  console.log(variables);
-
   const outputWithBreakLine = code.replace(/;/g, ";\n").replace(/{/g, "{\n");
 
   return (

--- a/packages/code-generator/src/CodeGenerator/index.tsx
+++ b/packages/code-generator/src/CodeGenerator/index.tsx
@@ -4,9 +4,7 @@ import { useDndMonitor, useDroppable } from "@dnd-kit/core";
 import { CodeViewer } from "@parser/components/file-parser/CodeViewer";
 import { Button } from "@ui/button";
 import { Separator } from "@ui/separator";
-import { useEffect, useState } from "react";
 import { useCodeGenerator } from "./context";
-import { generateCode } from "./functions";
 
 const FunctionDropZone: React.FC = () => {
   const { functions, setFunctions } = useCodeGenerator();
@@ -56,20 +54,10 @@ const FunctionDropZone: React.FC = () => {
 };
 
 export const CodeGenerator: React.FC = () => {
-  const { functions, setFunctions } = useCodeGenerator();
-  const [output, setOutput] = useState<string>("");
+  const { functions, setFunctions, code } = useCodeGenerator();
   const isEmpty = functions.length === 0;
 
-  const [outputWithBreakLine, setOutputWithBreakLine] = useState<string>("");
-
-  useEffect(() => {
-    const modifiedOutput = output.replace(/;/g, ";\n").replace(/{/g, "{\n");
-    setOutputWithBreakLine(modifiedOutput);
-  }, [output]);
-
-  useEffect(() => {
-    setOutput(generateCode(functions));
-  }, [functions, setFunctions]);
+  const outputWithBreakLine = code.replace(/;/g, ";\n").replace(/{/g, "{\n");
 
   return (
     <section className="h-fit p-4 border border-gray-200 border-dashed rounded-md">


### PR DESCRIPTION
I refactored the code generator to add functionality of variable tracking and unique naming.

This PR covers the following:

1. **Variable Tracking**: Added a `variables` field to the `CodeGeneratorContext` to keep track of the current variables. Implemented the `extractVariables` function to extract variable information from `FunctionInfo` objects, including handling `Promise<T>` return types.

2. **Unique Variable Naming**: Modified the `createVariableWithFunctionCall` function to generate unique variable names when the same variable name is used multiple times. The variable naming logic considers the order of variables and assigns a numeric suffix (e.g., `user1`, `user2`) to ensure uniqueness. The first occurrence of a variable name does not have a numeric suffix.

3. **Update Parameters**: Updated the `createFunctionCall` function to use existing variables as parameters when available. I implemented the `findVariableByType` function to find variables of a specific type, considering the order of variables and the `toIndex` parameter.

4. **Add Tests**: Created structured test data to provide reusable test data for different test cases. The whole test file can be updated in another PR to use those.


Closes #10 
