### PR TITLE
Fix: Key combinations in SearchDialog component not working on Mac #22

### DIFF
--- a/apps/next/app/features/code-generator/Dialogs.tsx
+++ b/apps/next/app/features/code-generator/Dialogs.tsx
@@ -158,7 +158,7 @@ export const LoadDialog: React.FC = () => {
         }
       }
       if (loadDialogOpen) {
-        if (event.altKey && event.key >= "1" && event.key <= "9") {
+        if ((event.altKey || event.ctrlKey) && event.key >= "1" && event.key <= "9") {
           event.preventDefault();
           const index = parseInt(event.key) - 1;
           if (index < savedFunctions.length) {
@@ -193,7 +193,7 @@ export const LoadDialog: React.FC = () => {
                 className="flex justify-between items-center mb-2"
               >
                 <p className="font-medium">
-                  <KeyCombinationLabel>⌥ + {index + 1}</KeyCombinationLabel>
+                  <KeyCombinationLabel>Ctrl + {index + 1}</KeyCombinationLabel>
                   &nbsp;
                   {savedFunc.name}
                 </p>

--- a/apps/next/app/features/code-generator/Dialogs.tsx
+++ b/apps/next/app/features/code-generator/Dialogs.tsx
@@ -158,7 +158,7 @@ export const LoadDialog: React.FC = () => {
         }
       }
       if (loadDialogOpen) {
-        if ((event.altKey || event.ctrlKey) && event.key >= "1" && event.key <= "9") {
+        if (event.ctrlKey && event.key >= "1" && event.key <= "9") {
           event.preventDefault();
           const index = parseInt(event.key) - 1;
           if (index < savedFunctions.length) {

--- a/apps/next/components/SearchDialog.tsx
+++ b/apps/next/components/SearchDialog.tsx
@@ -39,7 +39,7 @@ export const SearchDialog: React.FC = () => {
         setOpen(true);
       }
       if (open) {
-        if (event.altKey && event.key >= "1" && event.key <= "9") {
+        if ((event.altKey || event.ctrlKey) && event.key >= "1" && event.key <= "9") {
           event.preventDefault();
           const index = parseInt(event.key) - 1;
           if (index < searchResults.length) {
@@ -102,7 +102,7 @@ export const SearchDialog: React.FC = () => {
                 className="flex items-center justify-between mb-2"
               >
                 <p className="font-medium">
-                  <KeyCombinationLabel>⌥ + {index + 1}</KeyCombinationLabel>
+                  <KeyCombinationLabel>Ctrl + {index + 1}</KeyCombinationLabel>
                   &nbsp;
                   <code>
                     {result.name}: {result.returnType}

--- a/apps/next/components/SearchDialog.tsx
+++ b/apps/next/components/SearchDialog.tsx
@@ -39,7 +39,7 @@ export const SearchDialog: React.FC = () => {
         setOpen(true);
       }
       if (open) {
-        if ((event.altKey || event.ctrlKey) && event.key >= "1" && event.key <= "9") {
+        if (event.ctrlKey && event.key >= "1" && event.key <= "9") {
           event.preventDefault();
           const index = parseInt(event.key) - 1;
           if (index < searchResults.length) {


### PR DESCRIPTION
I have added control key option and tested, everything works as expected on mac. Also I didn't change the previous solution so on Windows it should be still works. Solves the issue #22 .