### PR TITLE
Add Prisma generator configs

### DIFF
--- a/apps/next/app/features/prisma/PrismaGenerator.tsx
+++ b/apps/next/app/features/prisma/PrismaGenerator.tsx
@@ -10,18 +10,31 @@ import {
 import { useState } from "react";
 import { Button } from "@ui/button";
 import { ScrollArea } from "@ui/scroll-area";
-import { Copy } from "lucide-react";
+import { Copy, Settings, SquareCheckBig } from "lucide-react";
+import { Checkbox } from "@ui/checkbox";
+import { Popover, PopoverContent, PopoverTrigger } from "@ui/popover";
+import { Label } from "@ui/label";
+
+const OPERATIONS = ["create", "delete", "read", "update"] as const;
+type Operation = (typeof OPERATIONS)[number];
 
 export const PrismaGenerator: React.FC = () => {
   const [schemaInput, setSchemaInput] = useState("");
   const [crudOutputs, setCrudOutputs] = useState<CrudOutput>({});
+  const [usePrismaNamespace, setUsePrismaNamespace] = useState(true);
+  const [selectedOperations, setSelectedOperations] = useState<Operation[]>([
+    ...OPERATIONS,
+  ]);
   const { toast } = useToast();
 
   const handleGenerateClick = () => {
     const schemaParsed = parsePrismaSchema(schemaInput);
     setCrudOutputs(
       generateCrud(schemaParsed, {
-        operations: ["create", "delete", "read", "update"],
+        usePrismaNamespace,
+        ...(selectedOperations.length < OPERATIONS.length && {
+          operations: selectedOperations,
+        }),
       })
     );
   };
@@ -37,16 +50,76 @@ export const PrismaGenerator: React.FC = () => {
     });
   };
 
+  const handleSelectAllOperations = () => {
+    setSelectedOperations([...OPERATIONS]);
+  };
+
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center space-x-2">
+            <Checkbox
+              id="namespace"
+              checked={usePrismaNamespace}
+              onCheckedChange={(checked) =>
+                setUsePrismaNamespace(checked as boolean)
+              }
+            />
+            <Label htmlFor="namespace">use Prisma namespace</Label>
+          </div>
+
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="outline" size="icon">
+                <Settings className="h-4 w-4" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-48">
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <h4 className="font-medium text-sm py-2">operations</h4>
+                  {selectedOperations.length < OPERATIONS.length && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={handleSelectAllOperations}
+                    >
+                      <SquareCheckBig className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+                {OPERATIONS.map((op) => (
+                  <div key={op} className="flex items-center space-x-2">
+                    <Checkbox
+                      id={op}
+                      checked={selectedOperations.includes(op)}
+                      onCheckedChange={(checked) => {
+                        setSelectedOperations(
+                          checked
+                            ? [...selectedOperations, op]
+                            : selectedOperations.filter((o) => o !== op)
+                        );
+                      }}
+                    />
+                    <Label htmlFor={op}>{op}</Label>
+                  </div>
+                ))}
+              </div>
+            </PopoverContent>
+          </Popover>
+        </div>
+
         <Textarea
           onChange={(e) => setSchemaInput(e.target.value)}
           value={schemaInput}
           className="min-h-96"
         />
         <div className="flex justify-end">
-          <Button disabled={!schemaInput} onClick={handleGenerateClick}>
+          <Button
+            disabled={!schemaInput || selectedOperations.length === 0}
+            onClick={handleGenerateClick}
+          >
             Generate
           </Button>
         </div>
@@ -58,10 +131,10 @@ export const PrismaGenerator: React.FC = () => {
             <Button
               variant="ghost"
               size="icon"
-              className="absolute right-2 top-2 h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+              className="absolute right-4 top-4 opacity-0 group-hover:opacity-100 transition-opacity"
               onClick={() => handleCopyCard(operations)}
             >
-              <Copy className="h-3 w-3" />
+              <Copy className="h-4 w-4" />
             </Button>
             <CardHeader>
               <CardTitle className="text-sm font-mono">{filename}</CardTitle>

--- a/apps/next/app/page.tsx
+++ b/apps/next/app/page.tsx
@@ -15,8 +15,11 @@ export default function Home() {
           <Button asChild>
             <Link href="/features/code-generator">Code Generator</Link>
           </Button>
-          <Button asChild variant="secondary">
-            <Link href="/roadmap">Roadmap</Link>
+          <Button asChild variant="ghost">
+            <Link href="/features/prisma">Prisma</Link>
+          </Button>
+          <Button asChild variant="link">
+            <Link href="/features/prisma">Roadmap</Link>
           </Button>
           <Button asChild variant="ghost" size="icon">
             <Link

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "packages/*"
   ],
   "dependencies": {
-    "@ozhanefe/ts-codegenerator": "^2.9.1",
+    "@ozhanefe/ts-codegenerator": "^2.10.0",
     "immer": "^10.1.1",
     "lucide-react": "^0.424.0"
   }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,6 +26,7 @@
     "tailwindcss": "^3.4.1"
   },
   "dependencies": {
+    "@radix-ui/react-checkbox": "^1.1.2",
     "@radix-ui/react-collapsible": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-label": "^2.1.0",

--- a/packages/ui/src/checkbox.tsx
+++ b/packages/ui/src/checkbox.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { cn } from "@ui/utils/tailwind-utils";
+import { CheckIcon } from "@radix-ui/react-icons";
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      className
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <CheckIcon className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };


### PR DESCRIPTION
adds configuration options to the prisma generator component:

## features
- added prisma namespace toggle: users can now opt out of the 'Prisma.' prefix in generated types
- operation selection: users can now choose which crud operations to generate (create/read/update/delete)
- operations are all selected by default, matching the new default behavior of the generator
- removed hardcoded operations config

## components
- added shadcn checkbox component for namespace toggle
- added shadcn popover component with operation selection checkboxes
- select all operations button for quick selection